### PR TITLE
Fixed file path to string conversion on MSVC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,7 @@ public:
         size_t entries = 0;
         {
             // temporary kv store will handle closing the file again
-            KVStore tmp_store(temp_file);
+            KVStore tmp_store(temp_file.string());
             KVEntry entry;
             for (const auto& [key, pos] : m_keydir) {
                 (void)key; // ignore


### PR DESCRIPTION
Added explicit conversion from std::filesystem::path to std::string. Implicit conversion works on Linux but not MSVC, which caused the program compilation to fail.