### PR TITLE
Add mime type to storage

### DIFF
--- a/src/KVStore.cpp
+++ b/src/KVStore.cpp
@@ -5,7 +5,7 @@
 
 // error checked version of fwrite
 // returns negative value on error, otherwise 0
-static int file_write(const void* buffer, size_t size, std::FILE* file) {
+[[nodiscard]] static int file_write(const void* buffer, size_t size, std::FILE* file) {
     size_t n = std::fwrite(buffer, 1, size, file);
     if (n != size) {
         // error
@@ -17,7 +17,7 @@ static int file_write(const void* buffer, size_t size, std::FILE* file) {
 // error checked version of fread
 // returns negative value on error, 1 if less than size was read,
 // and otherwise 0
-static int file_read(void* buffer, size_t size, std::FILE* file) {
+[[nodiscard]] static int file_read(void* buffer, size_t size, std::FILE* file) {
     size_t n = std::fread(buffer, 1, size, file);
     if (n != size) {
         // error?

--- a/src/KVStore.h
+++ b/src/KVStore.h
@@ -19,11 +19,15 @@ private:
         uint32_t value;
         uint8_t bytes[sizeof(uint32_t)];
     };
+    // first 8 bytes are zero
+    // and must be the first thing in the file
     struct KVEntry {
         KVSize key_length;
-        std::string key;
         KVSize value_length;
+        KVSize mime_length;
+        std::string key;
         std::vector<uint8_t> value;
+        std::string mime;
 
         int read_from_file(std::FILE* file);
 
@@ -51,10 +55,10 @@ public:
 
     int index();
 
-    int write_entry(const std::string& key, const std::vector<uint8_t>& value);
+    int write_entry(const std::string& key, const std::vector<uint8_t>& value, const std::string& mime);
 
     // returns -1 on error, 0 on found and read, and 1 on not found
-    int read_entry(const std::string& key, std::vector<uint8_t>& out_value);
+    int read_entry(const std::string& key, std::vector<uint8_t>& out_value, std::string& out_mime);
 
 private:
     int write_entry_impl(const KVEntry& entry);


### PR DESCRIPTION
Store MIME type together with key + value, as to properly return the data later with the right type. Closes #5.