### PR TITLE
`/all-keys` endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,9 @@ include(cmake/Git.cmake)
 ### SETTINGS ###
 
 # add all headers (.h, .hpp) to this
-set(PRJ_HEADERS src/KVStore.h)
+set(PRJ_HEADERS src/KVStore.h src/Accept.h)
 # add all source files (.cpp) to this, except the one with main()
-set(PRJ_SOURCES src/KVStore.cpp)
+set(PRJ_SOURCES src/KVStore.cpp src/Accept.cpp)
 # set the source file containing main()
 set(PRJ_MAIN src/main.cpp)
 # set the source file containing the test's main

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A simple, fast, persistent (disk-backed) key-value store with REST API, written in C++.
 
+Since v2.0.0, the MIME type of the data is stored, too.
+
 ## How to use
 
 Do NOT expose this to the internet without sufficient authentication by a proxy. 
@@ -46,7 +48,7 @@ $ curl localhost:8080/kv/language
 C++
 ```
 
-You can, of couse, also POST and GET binary data, such as files (any data up to 4GB), or json, or whatever you like. It will always be returned as `application/octet-stream`, as of v1.0.0.
+You can, of couse, also POST and GET binary data, such as files (any data up to 4GB), or json, or whatever you like. It will always be returned as the MIME type you stored it with (or `application/octet-stream`, if `Content-Type` was not supplied).
 
 ## Performance
 

--- a/src/Accept.cpp
+++ b/src/Accept.cpp
@@ -1,0 +1,120 @@
+#include "Accept.h"
+
+#include <algorithm>
+#include <boost/fusion/sequence/intrinsic_fwd.hpp>
+#include <boost/phoenix.hpp>
+#include <boost/spirit/home/qi/directive/lexeme.hpp>
+#include <boost/spirit/home/qi/parse.hpp>
+#include <boost/spirit/home/support/char_class.hpp>
+#include <boost/spirit/home/support/common_terminals.hpp>
+#include <boost/spirit/include/qi.hpp>
+#include <compare>
+#include <doctest/doctest.h>
+#include <fmt/core.h>
+#include <optional>
+
+AcceptValues::AcceptValues(const std::string& raw) {
+    using namespace boost::spirit;
+    using namespace boost;
+    using qi::_1;
+
+    using Accept = boost::fusion::vector<std::string, std::string, std::optional<float>>;
+
+    qi::rule<std::string::const_iterator, Accept> single;
+
+    single %= (+(qi::char_("a-zA-Z\\-\\+")) | qi::char_('*')) >> '/'
+        >> (+(qi::char_("a-zA-Z\\-\\+")) | qi::char_("*"))
+        >> -(";q=" >> qi::float_);
+
+    qi::rule<std::string::const_iterator, std::vector<Accept>> multiple;
+
+    multiple %= single % ',';
+
+    std::vector<Accept> res;
+
+    qi::phrase_parse(raw.begin(), raw.end(),
+        multiple[phoenix::ref(res) = _1],
+        ascii::space);
+
+    for (const auto& entry : res) {
+        AcceptMime mime;
+        mime.type = boost::fusion::at_c<0>(entry);
+        mime.subtype = boost::fusion::at_c<1>(entry);
+        mime.q_factor = boost::fusion::at_c<2>(entry).value_or(1.0f);
+        m_values.push_back(mime);
+    }
+    std::sort(m_values.begin(), m_values.end());
+}
+
+TEST_CASE("AcceptValues") {
+    AcceptValues a("text/html,text/*,application/json;q=0.3,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+
+    SUBCASE("simple") {
+        auto result = a.highest_in({ { "text", "html" } });
+        CHECK_EQ(result.type, "text");
+        CHECK_EQ(result.subtype, "html");
+    }
+
+    SUBCASE("multiple options") {
+        auto result = a.highest_in({ { "text", "html" }, { "application", "xml" } });
+        CHECK_EQ(result.type, "text");
+        CHECK_EQ(result.subtype, "html");
+    }
+
+    SUBCASE("specificity") {
+        auto result = a.highest_in({ { "text", "html" }, { "text", "*" } });
+        CHECK_EQ(result.type, "text");
+        CHECK_EQ(result.subtype, "html");
+    }
+
+    SUBCASE("specificity 2") {
+        auto result = a.highest_in({ { "*", "*" }, { "text", "*" } });
+        CHECK_EQ(result.type, "text");
+        CHECK_EQ(result.subtype, "*");
+    }
+
+    SUBCASE("q factors") {
+        auto result = a.highest_in({ { "application", "xml" }, { "application", "json" } });
+        CHECK_EQ(result.type, "application");
+        CHECK_EQ(result.subtype, "xml");
+    }
+}
+
+std::strong_ordering operator<=>(const AcceptMime& a, const AcceptMime& b) {
+    if (a.q_factor > b.q_factor) {
+        return std::strong_ordering::less;
+    } else {
+        if (a.type == "*" && b.type != "*") {
+            return std::strong_ordering::greater;
+        } else if (b.type == "*" && a.type != "*") {
+            return std::strong_ordering::less;
+        } else if (a.subtype == "*" && b.subtype != "*") {
+            return std::strong_ordering::greater;
+        } else if (b.subtype == "*" && a.subtype != "*") {
+            return std::strong_ordering::less;
+        } else {
+            return std::strong_ordering::equal;
+        }
+    }
+}
+
+Mime AcceptValues::highest_in(const std::vector<Mime>& options) {
+    std::vector<AcceptMime> matches;
+    for (const auto& val : m_values) {
+        auto iter = std::find_if(options.begin(), options.end(),
+            [&val](const auto& opt) -> bool {
+                return val.type == opt.type && val.subtype == opt.subtype;
+            });
+        if (iter != options.end()) {
+            matches.push_back(val);
+        }
+    }
+
+    if (matches.empty()) {
+        return Mime { .type = "*", .subtype = "*" };
+    } else {
+        std::sort(matches.begin(), matches.end());
+        auto match = *matches.begin();
+        return Mime { .type = match.type, .subtype = match.subtype };
+    }
+}

--- a/src/Accept.h
+++ b/src/Accept.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <compare>
+#include <string>
+#include <vector>
+
+struct AcceptMime {
+    std::string type;
+    std::string subtype;
+    float q_factor;
+};
+
+struct Mime {
+    std::string type;
+    std::string subtype;
+};
+
+std::strong_ordering operator<=>(const AcceptMime& a, const AcceptMime& b);
+
+// Parses an Accept header
+class AcceptValues {
+public:
+    AcceptValues(const std::string& raw);
+
+    Mime highest_in(const std::vector<Mime>&);
+
+private:
+    std::vector<AcceptMime> m_values;
+};

--- a/src/KVStore.cpp
+++ b/src/KVStore.cpp
@@ -498,3 +498,12 @@ int KVStore::KVHeader::write_to_file(std::FILE* file) {
     }
     return 0;
 }
+
+std::vector<std::string> KVStore::get_all_keys() const {
+    std::vector<std::string> result;
+    for (const auto& [key, pos] : m_keydir) {
+        (void)pos;
+        result.push_back(key);
+    }
+    return result;
+}

--- a/src/KVStore.h
+++ b/src/KVStore.h
@@ -60,6 +60,8 @@ public:
     // returns -1 on error, 0 on found and read, and 1 on not found
     int read_entry(const std::string& key, std::vector<uint8_t>& out_value, std::string& out_mime);
 
+    std::vector<std::string> get_all_keys() const;
+
 private:
     int write_entry_impl(const KVEntry& entry);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#include "Accept.h"
+#include "KVStore.h"
 #include <cerrno>
 #include <csignal>
 #include <cstdint>
@@ -9,9 +11,9 @@
 #include <fmt/core.h>
 #include <httplib.h>
 #include <mutex>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
-#include "KVStore.h"
 
 static httplib::Server server {};
 
@@ -105,6 +107,43 @@ int main(int argc, char** argv) {
         } else {
             res.set_content(fmt::format("error: {}\n", std::strerror(ret)), "text/plain");
             res.status = 500;
+        }
+    });
+
+    server.Get("/all-keys", [&](const httplib::Request& req, httplib::Response& res) {
+        std::string accept = req.get_header_value("Accept");
+        const std::vector<Mime> allowed_types = {
+            { "application", "json" },
+            { "text", "html" },
+        };
+        if (accept.empty()) {
+            fmt::print("/all-keys requested without 'Accept' header, assuming application/json\n");
+            accept = "application/json";
+        } else {
+            // parses and sorts
+            AcceptValues values(accept);
+            Mime highest = values.highest_in(allowed_types);
+            if (highest.type == "*" && highest.subtype == "*") {
+                fmt::print("/all-keys request has 'Accept' header, but nothing this server can provide. Sending application/json instead.\n");
+                highest = allowed_types.front();
+            }
+            accept = highest.type + "/" + highest.subtype;
+        }
+        auto keys = kv.get_all_keys();
+        std::sort(keys.begin(), keys.end());
+        if (accept == "text/html") {
+            std::string html = R"(<!DOCTYPE html><head><meta charset="UTF-8"><title>all keys</title>)"
+                               R"(<style>body{font-family:sans-serif;margin-left:5%;margin-right:5%;}</style><body><table><tbody>)";
+            for (const auto& key : keys) {
+                html += fmt::format(R"(<tr><td>{}</td></tr>)", key);
+            }
+            html += R"(</tbody></table></body></html>)";
+            res.set_content(html, accept);
+        } else if (accept == "application/json") {
+            res.set_content(nlohmann::json(keys).dump(), accept);
+        } else {
+            res.status = 500;
+            res.set_content("Internal server error", "text/plain");
         }
     });
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,8 @@
   "dependencies": [
       "fmt",
       "doctest",
-      "cpp-httplib"
+      "cpp-httplib",
+      "nlohmann-json",
+      "boost-spirit"
   ]
 }


### PR DESCRIPTION
Serves text/html or application/json based on the 'Accept'. For this purpose, includes an (almost) full 'Accept' header parser using boost::spirit.

Examples:

Via curl (no `Accept`, so defaults to `application/json`: 
```
[
  "hello-world",
  "hello-world-2"
]
```
Via browser (asks for multiple, including `text/html`):
![image](https://user-images.githubusercontent.com/29932116/219714443-aabe78e5-fc0b-4366-ae20-35fbd5456f31.png)

